### PR TITLE
feat(sofort): do not deactivate the add-on if the PHP or Give Core minimum version does not match #3440

### DIFF
--- a/give-sofort.php
+++ b/give-sofort.php
@@ -115,7 +115,11 @@ class Give_Sofort_Gateway {
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
 	}
 
-
+	/**
+	 * Init the plugin after plugins_loaded so environment variables are set.
+	 *
+	 * @since 1.0.1
+	 */
 	public function init() {
 
 		$this->load_plugin_textdomain();
@@ -140,6 +144,8 @@ class Give_Sofort_Gateway {
 
 	/**
 	 * Load textdomain for translations.
+	 *
+	 * @since 1.0.1
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain( 'give-sofort', false, basename( dirname( __FILE__ ) ) . '/languages/' );
@@ -148,7 +154,7 @@ class Give_Sofort_Gateway {
 	/**
 	 * Check plugin environment.
 	 *
-	 * @since  1.0.0
+	 * @since 1.0.1
 	 * @access public
 	 *
 	 * @return bool
@@ -178,7 +184,7 @@ class Give_Sofort_Gateway {
 	/**
 	 * Check plugin for Give environment.
 	 *
-	 * @since  1.1.2
+	 * @since 1.0.1
 	 * @access public
 	 *
 	 * @return bool
@@ -206,7 +212,7 @@ class Give_Sofort_Gateway {
 	/**
 	 * Allow this class and other classes to add notices.
 	 *
-	 * @since 1.0
+	 * @since 1.0.1
 	 *
 	 * @param $slug
 	 * @param $class
@@ -222,7 +228,7 @@ class Give_Sofort_Gateway {
 	/**
 	 * Display admin notices.
 	 *
-	 * @since 1.0
+	 * @since 1.0.1
 	 */
 	public function admin_notices() {
 
@@ -252,7 +258,7 @@ class Give_Sofort_Gateway {
 	/**
 	 * Show activation banner for this add-on.
 	 *
-	 * @since 1.0
+	 * @since 1.0.1
 	 *
 	 * @return bool
 	 */
@@ -286,7 +292,7 @@ class Give_Sofort_Gateway {
 	/**
 	 * Implement Give Licensing for Give Sofort Add On.
 	 *
-	 * @since  1.0.1
+	 * @since 1.0.1
 	 * @access private
 	 */
 	private function licensing() {

--- a/give-sofort.php
+++ b/give-sofort.php
@@ -284,7 +284,7 @@ class Give_Sofort_Gateway {
 	}
 
 	/**
-	 * Implement Give Licensing for Give Mollie Add On.
+	 * Implement Give Licensing for Give Sofort Add On.
 	 *
 	 * @since  1.0.1
 	 * @access private

--- a/give-sofort.php
+++ b/give-sofort.php
@@ -77,6 +77,15 @@ class Give_Sofort_Gateway {
 	private static $instance;
 
 	/**
+	 * Notices (array)
+	 *
+	 * @since 1.0.1
+	 *
+	 * @var array
+	 */
+	public $notices = array();
+
+	/**
 	 * Main Sofort Instance
 	 *
 	 * @since     v1.0
@@ -86,17 +95,42 @@ class Give_Sofort_Gateway {
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new Give_Sofort_Gateway();
-			self::$instance->sofort_init();
+			self::$instance->setup();
 		}
 
 		return self::$instance;
 	}
 
+	/**
+	 * Setup Give Sofort Gateway.
+	 *
+	 * @since  1.0.1
+	 * @access private
+	 */
+	private function setup() {
 
-	public function sofort_init() {
+		// Give init hook.
+		add_action( 'give_init', array( $this, 'init' ), 10 );
+		add_action( 'admin_init', array( $this, 'check_environment' ), 999 );
+		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
+	}
+
+
+	public function init() {
+
+		$this->load_plugin_textdomain();
+		$this->licensing();
+
+		if ( ! $this->get_environment_warning() ) {
+			return;
+		}
 
 		// Actions
-		add_action( 'plugins_loaded', array( $this, 'load_plugin_textdomain' ) );
+		$this->activation_banner();
+
+		if ( is_admin() ) {
+			require_once GIVE_SOFORT_DIR . 'includes/admin/plugin-activation.php';
+		}
 
 		// Includes
 		include_once GIVE_SOFORT_DIR . 'includes/admin/class-admin-settings.php';
@@ -109,6 +143,156 @@ class Give_Sofort_Gateway {
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain( 'give-sofort', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+	}
+
+	/**
+	 * Check plugin environment.
+	 *
+	 * @since  1.0.0
+	 * @access public
+	 *
+	 * @return bool
+	 */
+	public function check_environment() {
+		// Flag to check whether plugin file is loaded or not.
+		$is_working = true;
+
+		// Load plugin helper functions.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		}
+
+		/* Check to see if Give is activated, if it isn't deactivate and show a banner. */
+		// Check for if give plugin activate or not.
+		$is_give_active = defined( 'GIVE_PLUGIN_BASENAME' ) ? is_plugin_active( GIVE_PLUGIN_BASENAME ) : false;
+
+		if ( empty( $is_give_active ) ) {
+			// Show admin notice.
+			$this->add_admin_notice( 'prompt_give_activate', 'error', sprintf( __( '<strong>Activation Error:</strong> You must have the <a href="%s" target="_blank">Give</a> plugin installed and activated for Give - Sofort to activate.', 'give-sofort' ), 'https://givewp.com' ) );
+			$is_working = false;
+		}
+
+		return $is_working;
+	}
+
+	/**
+	 * Check plugin for Give environment.
+	 *
+	 * @since  1.1.2
+	 * @access public
+	 *
+	 * @return bool
+	 */
+	public function get_environment_warning() {
+		// Flag to check whether plugin file is loaded or not.
+		$is_working = true;
+
+		// Verify dependency cases.
+		if (
+			defined( 'GIVE_VERSION' )
+			&& version_compare( GIVE_VERSION, GIVE_SOFORT_MIN_GIVE_VER, '<' )
+		) {
+
+			/* Min. Give. plugin version. */
+			// Show admin notice.
+			$this->add_admin_notice( 'prompt_give_incompatible', 'error', sprintf( __( '<strong>Activation Error:</strong> You must have the <a href="%s" target="_blank">Give</a> core version %s for the Give - Sofort add-on to activate.', 'give-sofort' ), 'https://givewp.com', GIVE_SOFORT_MIN_GIVE_VER ) );
+
+			$is_working = false;
+		}
+
+		return $is_working;
+	}
+
+	/**
+	 * Allow this class and other classes to add notices.
+	 *
+	 * @since 1.0
+	 *
+	 * @param $slug
+	 * @param $class
+	 * @param $message
+	 */
+	public function add_admin_notice( $slug, $class, $message ) {
+		$this->notices[ $slug ] = array(
+			'class'   => $class,
+			'message' => $message,
+		);
+	}
+
+	/**
+	 * Display admin notices.
+	 *
+	 * @since 1.0
+	 */
+	public function admin_notices() {
+
+		$allowed_tags = array(
+			'a'      => array(
+				'href'  => array(),
+				'title' => array(),
+				'class' => array(),
+				'id'    => array(),
+			),
+			'br'     => array(),
+			'em'     => array(),
+			'span'   => array(
+				'class' => array(),
+			),
+			'strong' => array(),
+		);
+
+		foreach ( (array) $this->notices as $notice_key => $notice ) {
+			echo "<div class='" . esc_attr( $notice['class'] ) . "'><p>";
+			echo wp_kses( $notice['message'], $allowed_tags );
+			echo '</p></div>';
+		}
+
+	}
+
+	/**
+	 * Show activation banner for this add-on.
+	 *
+	 * @since 1.0
+	 *
+	 * @return bool
+	 */
+	public function activation_banner() {
+
+		// Check for activation banner inclusion.
+		if (
+			! class_exists( 'Give_Addon_Activation_Banner' )
+			&& file_exists( GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php' )
+		) {
+			include GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php';
+		}
+
+		// Initialize activation welcome banner.
+		if ( class_exists( 'Give_Addon_Activation_Banner' ) ) {
+
+			// Only runs on admin.
+			$args = array(
+				'file'              => GIVE_SOFORT_FILE,
+				'name'              => __( 'Sofort Gateway', 'give-sofort' ),
+				'version'           => GIVE_SOFORT_VERSION,
+				'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=sofort' ),
+				'documentation_url' => 'http://docs.givewp.com/addon-sofort',
+				'support_url'       => 'https://givewp.com/support/',
+				'testing'           => false, // Never leave true.
+			);
+			new Give_Addon_Activation_Banner( $args );
+		}
+	}
+
+	/**
+	 * Implement Give Licensing for Give Mollie Add On.
+	 *
+	 * @since  1.0.1
+	 * @access private
+	 */
+	private function licensing() {
+		if ( class_exists( 'Give_License' ) ) {
+			new Give_License( GIVE_SOFORT_FILE, 'Sofort', GIVE_SOFORT_VERSION, 'WordImpress' );
+		}
 	}
 
 }
@@ -128,21 +312,7 @@ class Give_Sofort_Gateway {
  */
 
 function give_sofort() {
-
-	if ( ! class_exists( 'Give' ) ) {
-		return false;
-	}
-
-	if ( is_admin() ) {
-		require_once GIVE_SOFORT_DIR . 'includes/admin/plugin-activation.php';
-	}
-
-	// Setup licence.
-	if ( class_exists( 'Give_License' ) ) {
-		new Give_License( GIVE_SOFORT_FILE, 'Sofort', GIVE_SOFORT_VERSION, 'WordImpress' );
-	}
-
 	return Give_Sofort_Gateway::instance();
 }
 
-add_action( 'plugins_loaded', 'give_sofort' );
+give_sofort();

--- a/includes/admin/plugin-activation.php
+++ b/includes/admin/plugin-activation.php
@@ -3,84 +3,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-/**
- * Give Display Donors Activation Banner
- *
- * Includes and initializes Give activation banner class.
- *
- * @since 1.0
- */
-function give_sofort_activation_banner() {
-
-	// Check for if give plugin activate or not.
-	$is_give_active = defined( 'GIVE_PLUGIN_BASENAME' ) ? is_plugin_active( GIVE_SOFORT_BASENAME ) : false;
-
-	// Check to see if Give is activated, if it isn't deactivate and show a banner.
-	if ( current_user_can( 'activate_plugins' ) && ! $is_give_active ) {
-
-		add_action( 'admin_notices', 'give_sofort_inactive_notice' );
-
-		// Don't let this plugin activate.
-		deactivate_plugins( GIVE_SOFORT_BASENAME );
-
-		if ( isset( $_GET['activate'] ) ) {
-			unset( $_GET['activate'] );
-		}
-
-		return false;
-
-	}
-
-	// Check for activation banner inclusion.
-	if (
-		! class_exists( 'Give_Addon_Activation_Banner' )
-		&& file_exists( GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php' )
-	) {
-		include GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php';
-	}
-
-	// Initialize activation welcome banner.
-	if ( class_exists( 'Give_Addon_Activation_Banner' ) ) {
-
-		$args = array(
-			'file'              => GIVE_SOFORT_FILE,
-			'name'              => __( 'Sofort Gateway', 'give-sofort' ),
-			'version'           => GIVE_SOFORT_VERSION,
-			'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=sofort' ),
-			'documentation_url' => 'http://docs.givewp.com/addon-sofort',
-			'support_url'       => 'https://givewp.com/support/',
-			'testing'           => false, // Never leave true.
-		);
-
-		new Give_Addon_Activation_Banner( $args );
-	}
-
-	return false;
-
-}
-
-add_action( 'admin_init', 'give_sofort_activation_banner');
-
-/**
- * Notice for No Core Activation
- *
- * @since 1.0
- */
-function give_sofort_inactive_notice() {
-	echo '<div class="error"><p>' . __( '<strong>Activation Error:</strong> You must have the <a href="https://givewp.com/" target="_blank">Give</a> plugin installed and activated for the PayFast add-on to activate.', 'give-sofort' ) . '</p></div>';
-}
-
-/**
- * Notice for min. version violation.
- *
- * @since 1.0
- */
-function give_sofort_version_notice() {
-	echo '<div class="error"><p>' . sprintf( __( '<strong>Activation Error:</strong> You must have <a href="%1$s" target="_blank">Give</a> minimum version %2$s for the PayFast add-on to activate.', 'give-sofort' ), 'https://givewp.com', GIVE_SOFORT_MIN_GIVE_VER ) . '</p></div>';
-}
-
-
 /**
  * Plugins row action links
  *
@@ -90,7 +12,7 @@ function give_sofort_version_notice() {
  *
  * @return array An array of updated action links.
  */
-function give_sofort_plugin_action_links($actions ) {
+function give_sofort_plugin_action_links( $actions ) {
 	$new_actions = array(
 		'settings' => sprintf(
 			'<a href="%1$s">%2$s</a>',
@@ -102,7 +24,7 @@ function give_sofort_plugin_action_links($actions ) {
 	return array_merge( $new_actions, $actions );
 }
 
-add_filter( 'plugin_action_links_' . GIVE_SOFORT_BASENAME, 'give_sofort_plugin_action_links');
+add_filter( 'plugin_action_links_' . GIVE_SOFORT_BASENAME, 'give_sofort_plugin_action_links' );
 
 
 /**
@@ -110,12 +32,12 @@ add_filter( 'plugin_action_links_' . GIVE_SOFORT_BASENAME, 'give_sofort_plugin_a
  *
  * @since 1.0
  *
- * @param array  $plugin_meta An array of the plugin's metadata.
+ * @param array $plugin_meta An array of the plugin's metadata.
  * @param string $plugin_file Path to the plugin file, relative to the plugins directory.
  *
  * @return array
  */
-function give_sofort_plugin_row_meta($plugin_meta, $plugin_file ) {
+function give_sofort_plugin_row_meta( $plugin_meta, $plugin_file ) {
 
 	if ( $plugin_file !== GIVE_SOFORT_BASENAME ) {
 		return $plugin_meta;


### PR DESCRIPTION
## Description
PR to fix issue https://github.com/WordImpress/Give/issues/3440 in https://github.com/WordImpress/Give-Sofort/

## How Has This Been Tested?
Tested by activating the Add-on when Give Plugin is not activate 
Tested by activating the Add-on when Give Plugin is activated and version is less then what is required 
Tested by activating the Add-on when Give Plugin is activated and updated to the latest version 

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.